### PR TITLE
MATroph hCG

### DIFF
--- a/README hCG.txt
+++ b/README hCG.txt
@@ -1,0 +1,25 @@
+MATLAB Files to analyze hCG marker intensity in syncytiotrophoblast cells using RGB image. 
+Blue is DAPI,Red (r) and Green (g) markers intensity 
+Last updated: 06.22.2024
+--------------
+Files
+--------------
+* Function files 
+1. hCGintensity2Dfunctionbacksubtracted (main processing function to process raw image quantitative analysis for hCG staining)
+2. process_r_g (processing function to process raw image for total nuclei count)
+----------------
+* Script file
+1. hCGonly (main script file to run the code)
+----------------
+
+*Instructions: 
+- Keep all 3 files in same location
+- Only change hCGonly file 
+Lines 8-11 of “hCGonly”  are the only ones you should change
+
+- When using Matlab, file location is very important
+Right click, “Copy address as text”
+- All experimental images need to be under the same umbrella file
+
+
+

--- a/hCGintensity2Dfunctionbacksubtracted.m
+++ b/hCGintensity2Dfunctionbacksubtracted.m
@@ -1,0 +1,70 @@
+function [sumOfValues, meanIntensity] = hCGintensity2Dfunctionbacksubtracted(unprocessed_image, channel)
+    % Extract the specified channel
+    im = unprocessed_image(:, :, channel);
+    
+     % Calculate background intensity using a region of the original image
+    backgroundRegion = im(1:50, 1:50); % adjust as needed
+    backgroundIntensity = mean(backgroundRegion(:));
+    fprintf('Background Intensity: %f\n', backgroundIntensity);
+    
+    % Subtract the background intensity from the image
+    redChannel = double(im) - backgroundIntensity;
+    
+    % Ensure no negative values after subtraction
+    redChannel(redChannel < 0) = 0;
+    % Display the original red channel
+    %figure; imshow(im, []); title('Original Red Channel');
+    
+    % Normalize the image from 0 to 1
+    imn = mat2gray(redChannel, [0 2^24-1]); % assuming 16-bit image
+    
+    % Display the normalized image
+    %figure; imshow(imn); title('Normalized Image');
+    
+    % Apply adaptive thresholding
+    I = adaptthresh(imn, .0001, 'ForegroundPolarity', 'bright');
+    
+    % Create binary image
+    BW1 = imbinarize(imn, I);
+    
+    % Display the binary image after thresholding
+    %figure; imshow(BW1); title('Binary Image after Thresholding');
+    
+    % Eliminate objects that have fewer than 100 pixels
+    BW2 = bwareaopen(BW1, 100);
+    
+    % Display the binary image after removing small objects
+    %figure; imshow(BW2); title('Binary Image after Area Opening');
+    
+    % Fill holes in objects
+    BW4 = imfill(BW2, 'holes');
+    
+    % Display the binary image after filling holes
+    %figure; imshow(BW4); title('Binary Image after Hole Filling');
+    
+    % Processed image for further analysis
+    processed_image = BW4;
+    
+    % Get region properties for each object
+    %image_props = regionprops(BW4, im, 'all'); % return all quantitative measurements
+    
+   
+    
+    % Display the image after background subtraction
+    %figure; imshow(redChannel, []); title('Image after Background Subtraction');
+    
+    % Get sum of all pixel values after background subtraction
+    %sumOfValues = sum(redChannel(:));
+    sumOfValues = sum(BW4(:));
+    
+    % Get mean value of image intensity over all image pixels after background subtraction
+    %meanIntensity = mean2(redChannel);
+    meanIntensity = mean2(BW4);
+    
+    % Display diagnostic information
+    fprintf('Sum of Values: %f\n', sumOfValues);
+    fprintf('Mean Intensity: %f\n', meanIntensity);
+    %figure(1);imshow(BW4)
+    %figure(2);imshow(imn,[])
+    %figure(3); imshow (redChannel,[])
+end

--- a/hCGonly.m
+++ b/hCGonly.m
@@ -1,0 +1,74 @@
+clc
+clear all
+close all
+%%
+%% calling image locations - CHANGE THESE TO MATCH YOUR FILE LOCATIONS
+%Change dirname_c dirnameconstant dirnamevariable and sheetname%
+%everything else keep constant
+dirname_c="D:\Insulin proposal and images\STB data\IC\"; % calls file location folder for control image **keep slash at the end of this line
+dirnameconstant="D:\Insulin proposal and images\STB data\8_11_23 STB processed\experimental"; % part of the dirname that will not change **no slash at the end of this line
+dirnamevariable=["condition 1","condition 2"]; % part of the dirname that changes per image (there is a max of 702 condition)
+sheetname='STB analysis.xlsx';% output excel sheet name must be in (or will creat a file in) the folder matlab is open in **Any data already in this sheet will be writin over**
+%% put the unprocessed image in a loop
+%% processes the control
+imagelist=dir(fullfile(dirname_c,'*.tif'));% identifies files that end with .tif within that folder
+%%
+for i=1:length(imagelist)
+ disp('Working on Imaging')
+
+file_c=strcat(dirname_c,imagelist(i).name); % creates a variable with the full path to image # 1 (the file)
+im_c=imread(file_c); % reads the image into a variable with the format it is saved in
+
+%%process function: input image from imread and channel (1:red 2:green 3:blue) output image and properties of the image
+[RedSum_c(:,i),Red_mean_c(:,i)]=hCGintensity2Dfunctionbacksubtracted(im_c,1);(i);
+%[RedSum_c(:,i),Red_mean_c(:,i)]=hCGintensity2Dfunctionbacksubtract(im_c,2);(i); %green
+
+%[Greenim_c,Color_cg]=process_r_g(im_c,2);
+[Blueim_c,Blue_c]=process_r_g(im_c,3);
+% Get the total number of objects in Blue_c
+    
+end
+total_objects_Blue_c = numel(Blue_c);
+
+
+for x=1:length(dirnamevariable)
+%x=1; %used this for checking code
+A_R=[];
+A_G=[];
+A_R2=[];
+H=[];
+NE=[];
+dirnames=dirnameconstant+"\"+dirnamevariable(x)+"\";
+dirname=dirnames{1}; % converts to pc location
+disp(dirname)
+images=dir(fullfile(dirname,'*.tif'));% Identifies files that end with .tif within that folder
+%%
+for i=1:length(images)
+    disp('Working on Imaging')
+    file=strcat(dirname,images(i).name); % creates a variable with the full path to each image in the folder
+    im=imread(file); % reads the image into variable im, with the format it is saved in
+   %% same processing as control
+   [Blueim,Blue]=process_r_g(im,3);
+    [RedSum(:,i),Red_mean(:,i)]=hCGintensity2Dfunctionbacksubtracted(im,1);(i); % 1 is red channel
+  %  [Colorim_g,Color_g]=process_r_g(im,2);
+    v=dirnamevariable(x); 
+end
+total_objects_Blue = numel(Blue);
+    disp("printing to "+sheetname)
+writematrix("Red_Sum",sheetname,'Sheet',v,'Range',"A1:A"+"1",'UseExcel',true)%writes the condition name
+writematrix(RedSum(:),sheetname,'Sheet',v,'Range',"A2:A"+(length(RedSum)+1),'UseExcel',true)%writes the expresion value
+writematrix("Red_Mean",sheetname,'Sheet',v,'Range',"B1:B"+"1",'UseExcel',true)%writes the condition name
+writematrix(Red_mean(:),sheetname,'Sheet',v,'Range',"B2:B"+(length(Red_mean)+1),'UseExcel',true)
+
+writematrix("RedSum_c",sheetname,'Sheet',v,'Range',"C1:C"+"1",'UseExcel',true)%writes the condition name
+writematrix(RedSum_c(:),sheetname,'Sheet',v,'Range',"C2:C"+(length(RedSum_c)+1),'UseExcel',true)%writes the expresion value
+writematrix("Red_mean_c",sheetname,'Sheet',v,'Range',"D1:D"+"1",'UseExcel',true)%writes the condition name
+writematrix(Red_mean_c(:),sheetname,'Sheet',v,'Range',"D2:D"+(length(Red_mean_c)+1),'UseExcel',true)%writes the expresion value
+
+% Print total number of objects to Excel
+writematrix("Total Objects Blue_c", sheetname, 'Sheet', v, 'Range', "F1", 'UseExcel', true)
+writematrix(total_objects_Blue_c, sheetname, 'Sheet', v, 'Range', "F2", 'UseExcel', true)
+
+writematrix("Total Objects Blue", sheetname, 'Sheet', v, 'Range', "E1", 'UseExcel', true)
+writematrix(total_objects_Blue, sheetname, 'Sheet', v, 'Range', "E2", 'UseExcel', true)
+end 

--- a/process_r_g_hCG.m
+++ b/process_r_g_hCG.m
@@ -1,0 +1,16 @@
+function [processed_image,image_props] = process_r_g(unprocessed_image,channel)
+%image processing
+%   processes the image for quantitative analysis
+im=unprocessed_image(:,:,channel); % isolates the color channel
+imn=mat2gray(im,[0 2^24-1]); % normalizes the image from 0 to 1, the limits should be consistent with the bit depth of the image (2^16-1, in this case since 16 bit)
+I=adaptthresh(imn,.0001,'ForegroundPolarity','bright'); % thresholds the image based on local mean intensity in neighborhood of each pixel
+BW1=imbinarize(imn,I); % creates a binary image of 1s and 0s from threshold
+BW2=bwareaopen(BW1,100); % eliminates objects that have fewer than 100 pixels
+%BW3=imdilate(BW2,strel('sphere',1)); % dilates objects
+BW4=imfill(BW2,'holes'); % fills holes of objects
+processed_image=BW4;
+image_props=regionprops(BW4,im,'all'); %returns all quantitative measurements for each object
+%figure(1);imshow(BW4)
+%figure(2);imshow(imn,[])
+end
+


### PR DESCRIPTION
MATLAB Files to analyze hCG marker intensity in syncytiotrophoblast cells using RGB image. 
Blue is DAPI,Red (r) and Green (g) markers intensity 
Last updated: 06.22.2024
--------------
Files
--------------
* Function files 
1. hCGintensity2Dfunctionbacksubtracted (main processing function to process raw image quantitative analysis for hCG staining)
2. process_r_g (processing function to process raw image for total nuclei count)
----------------
* Script file
1. hCGonly (main script file to run the code)
----------------

*Instructions: 
- Keep all 3 files in same location
- Only change hCGonly file 
Lines 8-11 of “hCGonly”  are the only ones you should change

- When using Matlab, file location is very important
Right click, “Copy address as text”
- All experimental images need to be under the same umbrella file
